### PR TITLE
PD-39: Add 10.x pipeline tutorial series (PD-14)

### DIFF
--- a/content/10.0_Screen_1000_Peptides.ipynb
+++ b/content/10.0_Screen_1000_Peptides.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "961da28d",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Screen 1,000 Peptides Before Lunch\n\nMulti-stage pipeline to screen a peptide library for thermal stability and solubility.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Defining a multi-stage pipeline with parallel predictions\n- Filtering by melting temperature and solubility\n- Exploring results with `summary()`, `stats()`, and SQL queries\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d93c0767",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61e1c6ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3dd350a",
+   "metadata": {},
+   "source": [
+    "## Peptide library\n",
+    "\n",
+    "30 antimicrobial peptides of varying length, charge, and hydrophobicity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8964acfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MY_PEPTIDES = [\n",
+    "    # Magainins / frog-derived\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\",\n",
+    "    \"GIGKFLHSAGKFGKAFVGEIMKS\",\n",
+    "    \"GLFDIIKKIAESF\",\n",
+    "    \"GLFDIVKKVVGALGSL\",\n",
+    "    \"FLPLILRKIVTAL\",\n",
+    "    # Human defensins / cathelicidins\n",
+    "    \"LLGDFFRKSKEKIGKEFKRIVQRIKDFLRNLVPRTES\",\n",
+    "    \"RLFDKIRQVIRKF\",\n",
+    "    \"KWKLFKKIPKFLHLAKKF\",\n",
+    "    # Insect-derived\n",
+    "    \"GIGAVLKVLTTGLPALISWIKRKRQQ\",\n",
+    "    \"VDKGSYLPRPTPPRPIYNRN\",\n",
+    "    # Synthetic / designed\n",
+    "    \"KLAKLAKKLAKLAK\",\n",
+    "    \"LKLLKKLLKLLKKL\",\n",
+    "    \"RRWWRRWWRR\",\n",
+    "    \"KWKWKWKWKW\",\n",
+    "    \"GIKKFLGSIWKFIKAFVKEIMN\",\n",
+    "    # Short peptides\n",
+    "    \"RRWQWR\",\n",
+    "    \"RWRWRW\",\n",
+    "    \"FKRIVQRIKDFL\",\n",
+    "    \"KFLKKAKKFGK\",\n",
+    "    \"GIGKFLHSAK\",\n",
+    "    \"KWKLFKKI\",\n",
+    "    \"RLFDKIRQ\",\n",
+    "    # Longer peptides\n",
+    "    \"GLFDIIKKIAESFLPKV\",\n",
+    "    \"GIGKFLHSAKKFGKAFV\",\n",
+    "    \"KWKLFKKIPKFLHLAK\",\n",
+    "]\n",
+    "print(f\"{len(MY_PEPTIDES)} peptides, length range: {min(len(s) for s in MY_PEPTIDES)}–{max(len(s) for s in MY_PEPTIDES)} aa\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3493036",
+   "metadata": {},
+   "source": [
+    "## Build and run the pipeline\n",
+    "\n",
+    "The dependency graph:\n",
+    "```\n",
+    "validate\n",
+    "   ├── predict_tm   ─┐\n",
+    "   └── predict_sol  ─┴── filter_tm >= 40°C ── rank top 15 by solubility\n",
+    "```\n",
+    "Both prediction stages run in **parallel** because they share the same dependency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25caf0c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = DataPipeline(sequences=MY_PEPTIDES, verbose=True)\n",
+    "\n",
+    "pipeline.add_filter(ValidAminoAcidFilter(), stage_name=\"validate\")\n",
+    "\n",
+    "pipeline.add_prediction(\n",
+    "    \"temperature-regression\", extractions=\"prediction\",\n",
+    "    columns=\"melting_temperature\", stage_name=\"predict_tm\",\n",
+    "    depends_on=[\"validate\"],\n",
+    ")\n",
+    "pipeline.add_prediction(\n",
+    "    \"biolmsol\", extractions=\"solubility_score\",\n",
+    "    columns=\"solubility\", stage_name=\"predict_sol\",\n",
+    "    depends_on=[\"validate\"],\n",
+    ")\n",
+    "\n",
+    "pipeline.add_filter(ThresholdFilter(\"melting_temperature\", min_value=40.0), stage_name=\"filter_tm\")\n",
+    "pipeline.add_filter(RankingFilter(\"solubility\", n=15, ascending=False), stage_name=\"top15\")\n",
+    "\n",
+    "pipeline.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f0d894a",
+   "metadata": {},
+   "source": [
+    "## Explore results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a01104cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53effee4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.stats()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2002d96f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Top 10 sequences by melting temperature\n",
+    "pipeline.query(\"\"\"\n",
+    "    SELECT s.sequence,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'melting_temperature' THEN p.value END) AS tm,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'solubility' THEN p.value END) AS solubility\n",
+    "    FROM sequences s\n",
+    "    JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    GROUP BY s.sequence\n",
+    "    ORDER BY tm DESC\n",
+    "    LIMIT 10\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c300ee4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.plot(\"funnel\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1733920",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.0_Screen_1000_Peptides.ipynb
+++ b/content/10.0_Screen_1000_Peptides.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Defining a multi-stage pipeline with parallel predictions\n- Filtering by melting temperature and solubility\n- Exploring results with `summary()`, `stats()`, and SQL queries\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.1_Why_DuckDB_Inside_SDK.ipynb
+++ b/content/10.1_Why_DuckDB_Inside_SDK.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- How sequence deduplication and cache lookup work under the hood\n- How to query the DuckDB store directly with arbitrary SQL\n- How to resume a pipeline after a crash or session restart\n\n**Requirements:**\n```\npip install biolmai[pipeline]\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.1_Why_DuckDB_Inside_SDK.ipynb
+++ b/content/10.1_Why_DuckDB_Inside_SDK.ipynb
@@ -1,0 +1,201 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "16352875",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Why DuckDB Inside the SDK\n\nHow the SDK uses DuckDB for caching, deduplication, and zero-cost re-querying.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- How sequence deduplication and cache lookup work under the hood\n- How to query the DuckDB store directly with arbitrary SQL\n- How to resume a pipeline after a crash or session restart\n\n**Requirements:**\n```\npip install biolmai[pipeline]\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "644807d0",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5992725b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "224e7aa9",
+   "metadata": {},
+   "source": [
+    "## The cache in action\n",
+    "\n",
+    "Run a pipeline, then re-run it. The second run fires zero API calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "270a16dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PEPTIDES = [\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\",\n",
+    "    \"GLFDIIKKIAESF\",\n",
+    "    \"KLAKLAKKLAKLAK\",\n",
+    "    \"RRWWRRWWRR\",\n",
+    "    \"KWKLFKKI\",\n",
+    "]\n",
+    "\n",
+    "ds = DuckDBDataStore(\"sdk_demo.duckdb\")\n",
+    "\n",
+    "pipeline = DataPipeline(sequences=PEPTIDES, datastore=ds, run_id=\"run_v1\", verbose=True)\n",
+    "pipeline.add_prediction(\"temperature-regression\", extractions=\"prediction\", columns=\"melting_temperature\")\n",
+    "pipeline.add_prediction(\"biolmsol\", extractions=\"solubility_score\", columns=\"solubility\")\n",
+    "pipeline.run()\n",
+    "print(\"Run 1 complete — check the API call count above\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a302aea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-run identical pipeline — 0 API calls\n",
+    "pipeline2 = DataPipeline(sequences=PEPTIDES, datastore=ds, run_id=\"run_v1\", verbose=True)\n",
+    "pipeline2.add_prediction(\"temperature-regression\", extractions=\"prediction\", columns=\"melting_temperature\")\n",
+    "pipeline2.add_prediction(\"biolmsol\", extractions=\"solubility_score\", columns=\"solubility\")\n",
+    "pipeline2.run()\n",
+    "print(\"Run 2 complete — all served from cache\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c335456",
+   "metadata": {},
+   "source": [
+    "## Query the DuckDB store directly\n",
+    "\n",
+    "The `.duckdb` file is a standard DuckDB database. You can run arbitrary SQL against it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "066c1fe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Schema overview\n",
+    "ds.conn.execute(\"\"\"\n",
+    "    SELECT prediction_type, model_name, COUNT(*) AS n, \n",
+    "           ROUND(AVG(value), 3) AS mean, ROUND(MIN(value), 3) AS min, ROUND(MAX(value), 3) AS max\n",
+    "    FROM predictions\n",
+    "    GROUP BY prediction_type, model_name\n",
+    "\"\"\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fef5e40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Full prediction history for every sequence\n",
+    "ds.conn.execute(\"\"\"\n",
+    "    SELECT s.sequence, p.prediction_type, ROUND(p.value, 3) AS value\n",
+    "    FROM sequences s\n",
+    "    JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    ORDER BY s.sequence, p.prediction_type\n",
+    "\"\"\").df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c128de89",
+   "metadata": {},
+   "source": [
+    "## Re-filter without re-predicting\n",
+    "\n",
+    "Change your filter threshold and re-run — predictions are already cached."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77726bb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline3 = DataPipeline(sequences=PEPTIDES, datastore=ds, run_id=\"run_v3_strict\", verbose=True)\n",
+    "pipeline3.add_prediction(\"temperature-regression\", extractions=\"prediction\", columns=\"melting_temperature\")\n",
+    "pipeline3.add_prediction(\"biolmsol\", extractions=\"solubility_score\", columns=\"solubility\")\n",
+    "pipeline3.add_filter(ThresholdFilter(\"melting_temperature\", min_value=50.0))  # stricter threshold\n",
+    "pipeline3.run()\n",
+    "pipeline3.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df178fac",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10fd4454",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n",
+    "import os; os.remove(\"sdk_demo.duckdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.2_Cluster_By_Embedding.ipynb
+++ b/content/10.2_Cluster_By_Embedding.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Generating ESM2-8m embeddings via the pipeline SDK\n- K-means clustering with silhouette score selection\n- PCA visualization of sequence space\n- Diversity sampling across clusters\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib scikit-learn\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.3_Trickle_Pattern.ipynb
+++ b/content/10.3_Trickle_Pattern.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Persisting predictions across multiple pipeline runs with a named `DuckDBDataStore`\n- The anti-join cache lookup that skips already-predicted sequences\n- Changing filter thresholds with zero API calls\n- Querying the full campaign history\n\n**Requirements:**\n```\npip install biolmai[pipeline]\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.3_Trickle_Pattern.ipynb
+++ b/content/10.3_Trickle_Pattern.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "10a34ad3",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# The Trickle Pattern\n\nIterative screening: add new sequences across rounds without re-predicting cached ones.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Persisting predictions across multiple pipeline runs with a named `DuckDBDataStore`\n- The anti-join cache lookup that skips already-predicted sequences\n- Changing filter thresholds with zero API calls\n- Querying the full campaign history\n\n**Requirements:**\n```\npip install biolmai[pipeline]\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b0f851a",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed2c44d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620f7832",
+   "metadata": {},
+   "source": [
+    "## Round 1: initial screen\n",
+    "\n",
+    "500 sequences, two models. All predictions cached to `campaign.duckdb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "849d1e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BATCH_1 = [\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\", \"GLFDIIKKIAESF\", \"KLAKLAKKLAKLAK\",\n",
+    "    \"RRWWRRWWRR\", \"KWKLFKKI\", \"GIGKFLHSAK\", \"RLFDKIRQ\",\n",
+    "    \"GLFDIVKKVVGALGSL\", \"FLPLILRKIVTAL\", \"KWKWKWKWKW\",\n",
+    "]  # In practice: 500 sequences\n",
+    "\n",
+    "pipeline_v1 = DataPipeline(\n",
+    "    sequences=BATCH_1,\n",
+    "    datastore=DuckDBDataStore(\"campaign.duckdb\"),\n",
+    "    run_id=\"screen_v1\",\n",
+    "    verbose=True,\n",
+    ")\n",
+    "pipeline_v1.add_prediction(\"temperature-regression\", extractions=\"prediction\",\n",
+    "                            columns=\"melting_temperature\")\n",
+    "pipeline_v1.add_prediction(\"biolmsol\", extractions=\"solubility_score\",\n",
+    "                            columns=\"solubility\")\n",
+    "pipeline_v1.add_filter(ThresholdFilter(\"melting_temperature\", min_value=40.0))\n",
+    "pipeline_v1.run()\n",
+    "print(f\"Round 1: {len(BATCH_1)} sequences predicted and cached\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a87c6a5",
+   "metadata": {},
+   "source": [
+    "## Round 2: new sequences arrive\n",
+    "\n",
+    "Feed the full combined list — old + new — into the same DB. Only new sequences hit the API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89942ba7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BATCH_2 = [\n",
+    "    \"GIKKFLGSIWKFIKAFVKEIMN\", \"RRLCRIVVIRVCR\", \"RRWQWR\",\n",
+    "    \"RWRWRW\", \"FKRIVQRIKDFL\", \"KWKLFKKIPKFLHLAK\",\n",
+    "]  # In practice: 200 new sequences\n",
+    "\n",
+    "ALL_SEQUENCES = BATCH_1 + BATCH_2\n",
+    "\n",
+    "pipeline_v2 = DataPipeline(\n",
+    "    sequences=ALL_SEQUENCES,\n",
+    "    datastore=DuckDBDataStore(\"campaign.duckdb\"),  # same DB\n",
+    "    run_id=\"screen_v2\",\n",
+    "    verbose=True,\n",
+    ")\n",
+    "pipeline_v2.add_prediction(\"temperature-regression\", extractions=\"prediction\",\n",
+    "                            columns=\"melting_temperature\")\n",
+    "pipeline_v2.add_prediction(\"biolmsol\", extractions=\"solubility_score\",\n",
+    "                            columns=\"solubility\")\n",
+    "pipeline_v2.add_filter(ThresholdFilter(\"melting_temperature\", min_value=40.0))\n",
+    "pipeline_v2.run()\n",
+    "print(f\"Round 2: only {len(BATCH_2)} new sequences hit the API — {len(BATCH_1)} served from cache\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3af2581a",
+   "metadata": {},
+   "source": [
+    "## Round 3: tighten filters, zero API calls\n",
+    "\n",
+    "Wet-lab results suggest the Tm threshold should be higher. No new sequences — just a stricter filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce5c42d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline_v3 = DataPipeline(\n",
+    "    sequences=ALL_SEQUENCES,\n",
+    "    datastore=DuckDBDataStore(\"campaign.duckdb\"),\n",
+    "    run_id=\"screen_v3\",\n",
+    "    verbose=True,\n",
+    ")\n",
+    "pipeline_v3.add_prediction(\"temperature-regression\", extractions=\"prediction\",\n",
+    "                            columns=\"melting_temperature\")\n",
+    "pipeline_v3.add_prediction(\"biolmsol\", extractions=\"solubility_score\",\n",
+    "                            columns=\"solubility\")\n",
+    "pipeline_v3.add_filter(ThresholdFilter(\"melting_temperature\", min_value=55.0))  # stricter\n",
+    "pipeline_v3.run()\n",
+    "pipeline_v3.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a45ec95b",
+   "metadata": {},
+   "source": [
+    "## Query campaign history\n",
+    "\n",
+    "The database contains every prediction across all rounds. Fully queryable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97c0cf1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = DuckDBDataStore(\"campaign.duckdb\")\n",
+    "ds.conn.execute(\"\"\"\n",
+    "    SELECT s.sequence,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'melting_temperature' THEN ROUND(p.value,1) END) AS tm,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'solubility' THEN ROUND(p.value,3) END) AS solubility\n",
+    "    FROM sequences s\n",
+    "    JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    GROUP BY s.sequence\n",
+    "    ORDER BY tm DESC\n",
+    "\"\"\").df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174ab4ef",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd25f529",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n",
+    "import os; os.remove(\"campaign.duckdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.4_Mutation_Scanning.ipynb
+++ b/content/10.4_Mutation_Scanning.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Generating a complete single-point mutant library programmatically\n- Running multi-model predictions with parallel stages\n- Visualizing a ΔTm mutational landscape heatmap\n- Multi-model consensus ranking\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib numpy\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.4_Mutation_Scanning.ipynb
+++ b/content/10.4_Mutation_Scanning.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6fb79df8",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Mutation Scanning\n\nScore all single-point variants of a target sequence and visualize the mutational landscape.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Generating a complete single-point mutant library programmatically\n- Running multi-model predictions with parallel stages\n- Visualizing a ΔTm mutational landscape heatmap\n- Multi-model consensus ranking\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib numpy\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b442963",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0318847b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8527bcc",
+   "metadata": {},
+   "source": [
+    "## Generate the single-point mutant library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4faa91ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WILD_TYPE = \"MKTAYIAKQRQISFVKSHFSRQLEER\"\n",
+    "CDR3_START, CDR3_END = 5, 22   # 17-residue target region\n",
+    "AMINO_ACIDS = \"ACDEFGHIKLMNPQRSTVWY\"\n",
+    "\n",
+    "variants = [WILD_TYPE]  # include wild type as reference\n",
+    "for pos in range(CDR3_START, CDR3_END):\n",
+    "    for aa in AMINO_ACIDS:\n",
+    "        if aa != WILD_TYPE[pos]:\n",
+    "            mutant = WILD_TYPE[:pos] + aa + WILD_TYPE[pos+1:]\n",
+    "            variants.append(mutant)\n",
+    "\n",
+    "print(f\"{len(variants)} sequences ({len(variants)-1} single-point variants + wild type)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8061bb63",
+   "metadata": {},
+   "source": [
+    "## Score with multiple models\n",
+    "\n",
+    "Both prediction stages run in parallel. 324 sequences × 2 models, all cached in DuckDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0963d9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from biolmai.pipeline import DataPipeline, ThresholdFilter, RankingFilter\n",
+    "\n",
+    "pipeline = DataPipeline(sequences=variants, verbose=True)\n",
+    "\n",
+    "pipeline.add_prediction(\n",
+    "    \"temperature-regression\", extractions=\"prediction\",\n",
+    "    columns=\"melting_temperature\", stage_name=\"tm\",\n",
+    ")\n",
+    "pipeline.add_prediction(\n",
+    "    \"biolmsol\", extractions=\"solubility_score\",\n",
+    "    columns=\"solubility\", stage_name=\"sol\",\n",
+    ")\n",
+    "\n",
+    "# Keep variants that beat wild-type Tm floor, then top 20 by solubility\n",
+    "pipeline.add_filter(ThresholdFilter(\"melting_temperature\", min_value=55.0))\n",
+    "pipeline.add_filter(RankingFilter(\"solubility\", n=20, ascending=False))\n",
+    "\n",
+    "pipeline.run()\n",
+    "pipeline.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc1218d1",
+   "metadata": {},
+   "source": [
+    "## Compute ΔTm relative to wild type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d864844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pipeline.query(\"\"\"\n",
+    "    SELECT s.sequence,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'melting_temperature' THEN p.value END) AS tm,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'solubility' THEN p.value END) AS solubility\n",
+    "    FROM sequences s\n",
+    "    JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    GROUP BY s.sequence\n",
+    "\"\"\")\n",
+    "\n",
+    "wt_tm = df[df[\"sequence\"] == WILD_TYPE][\"tm\"].iloc[0]\n",
+    "df[\"delta_tm\"] = df[\"tm\"] - wt_tm\n",
+    "print(f\"Wild-type Tm: {wt_tm:.1f}°C\")\n",
+    "df.sort_values(\"delta_tm\", ascending=False).head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b7b4e44",
+   "metadata": {},
+   "source": [
+    "## Mutational landscape heatmap\n",
+    "\n",
+    "Each cell shows the predicted ΔTm for substituting the column's wild-type residue with the row's amino acid. Red = stabilizing, blue = destabilizing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4589491f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "positions = list(range(CDR3_START, CDR3_END))\n",
+    "aa_list = sorted(AMINO_ACIDS)\n",
+    "heatmap = np.full((len(aa_list), len(positions)), np.nan)\n",
+    "\n",
+    "for i, aa in enumerate(aa_list):\n",
+    "    for j, pos in enumerate(positions):\n",
+    "        if aa == WILD_TYPE[pos]:\n",
+    "            continue\n",
+    "        mutant = WILD_TYPE[:pos] + aa + WILD_TYPE[pos+1:]\n",
+    "        row = df[df[\"sequence\"] == mutant]\n",
+    "        if len(row) > 0:\n",
+    "            heatmap[i, j] = row[\"delta_tm\"].iloc[0]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 6))\n",
+    "im = ax.imshow(heatmap, cmap=\"RdBu_r\", aspect=\"auto\", vmin=-10, vmax=10)\n",
+    "ax.set_xticks(range(len(positions)))\n",
+    "ax.set_xticklabels([WILD_TYPE[p] + str(p+1) for p in positions], rotation=90)\n",
+    "ax.set_yticks(range(len(aa_list)))\n",
+    "ax.set_yticklabels(aa_list)\n",
+    "plt.colorbar(im, ax=ax, label=\"ΔTm (°C) vs. wild type\")\n",
+    "ax.set_title(\"Saturation mutagenesis: predicted ΔTm landscape\")\n",
+    "ax.set_xlabel(\"Position (wild-type residue + number)\")\n",
+    "ax.set_ylabel(\"Substitution amino acid\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f36bdbf5",
+   "metadata": {},
+   "source": [
+    "## Multi-model consensus\n",
+    "\n",
+    "Normalize scores across models and rank by average — mutations that score well on independent predictors are more likely to validate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bb33d34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df_filt = pipeline.get_final_data()\n",
+    "df_filt[\"tm_norm\"] = (df_filt[\"melting_temperature\"] - df_filt[\"melting_temperature\"].mean()) / df_filt[\"melting_temperature\"].std()\n",
+    "df_filt[\"sol_norm\"] = (df_filt[\"solubility\"] - df_filt[\"solubility\"].mean()) / df_filt[\"solubility\"].std()\n",
+    "df_filt[\"consensus\"] = (df_filt[\"tm_norm\"] + df_filt[\"sol_norm\"]) / 2\n",
+    "\n",
+    "print(\"Top 10 consensus candidates:\")\n",
+    "df_filt.nlargest(10, \"consensus\")[[\"sequence\", \"melting_temperature\", \"solubility\", \"consensus\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.5_Protein_Is_A_Point.ipynb
+++ b/content/10.5_Protein_Is_A_Point.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Tool 1: \"Find me more like this one\" — cosine similarity search\n- Tool 2: \"Is this sequence weird?\" — outlier detection\n- Tool 3: \"Show me the landscape\" — PCA colored by predicted property\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib numpy scikit-learn\nexport BIOLMAI_TOKEN=your-token-here\n```"

--- a/content/10.5_Protein_Is_A_Point.ipynb
+++ b/content/10.5_Protein_Is_A_Point.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "481fcb08",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Protein Is a Point\n\nUse embeddings as feature vectors for similarity search, outlier detection, and landscape visualization.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Tool 1: \"Find me more like this one\" — cosine similarity search\n- Tool 2: \"Is this sequence weird?\" — outlier detection\n- Tool 3: \"Show me the landscape\" — PCA colored by predicted property\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib numpy scikit-learn\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cc45d4",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dcbf2db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.decomposition import PCA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58be962d",
+   "metadata": {},
+   "source": [
+    "## Get embeddings for a peptide library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74e5899d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LIBRARY = [\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\", \"GLFDIIKKIAESF\", \"KLAKLAKKLAKLAK\",\n",
+    "    \"RRWWRRWWRR\", \"KWKLFKKI\", \"GIGKFLHSAK\", \"RLFDKIRQ\",\n",
+    "    \"GLFDIVKKVVGALGSL\", \"FLPLILRKIVTAL\", \"KWKWKWKWKW\",\n",
+    "    \"GIKKFLGSIWKFIKAFVKEIMN\", \"RRLCRIVVIRVCR\", \"RRWQWR\",\n",
+    "    \"RWRWRW\", \"FKRIVQRIKDFL\", \"KWKLFKKIPKFLHLAK\",\n",
+    "    \"GLFDIIKKIAESFLPKV\", \"GIGKFLHSAKKFGKAFV\", \"KWKLFKKIPKFLHLAKKF\",\n",
+    "    \"LLGDFFRKSKEKIGKEFKRIVQRIKDFLRNLVPRTES\",\n",
+    "]\n",
+    "\n",
+    "HIT_SEQUENCE = LIBRARY[0]  # our \"hit\" from a previous screen\n",
+    "\n",
+    "ds = DuckDBDataStore(\"embedding_demo.duckdb\")\n",
+    "pipeline = DataPipeline(sequences=LIBRARY, datastore=ds, verbose=True)\n",
+    "pipeline.add_prediction(\n",
+    "    \"esm2-8m\", action=\"encode\",\n",
+    "    embedding_extractor=EmbeddingSpec(key=\"embeddings\", layer=6),\n",
+    "    stage_name=\"embed\",\n",
+    ")\n",
+    "pipeline.run()\n",
+    "\n",
+    "sequence_ids = [r[0] for r in ds.conn.execute(\"SELECT sequence_id FROM sequences ORDER BY sequence_id\").fetchall()]\n",
+    "sequences   = [r[0] for r in ds.conn.execute(\"SELECT sequence FROM sequences ORDER BY sequence_id\").fetchall()]\n",
+    "emb_map = ds.get_embeddings_bulk(sequence_ids, model_name=\"esm2-8m\")\n",
+    "mat = np.stack([emb_map[sid] for sid in sequence_ids])\n",
+    "print(f\"Embedding matrix: {mat.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7ee365d",
+   "metadata": {},
+   "source": [
+    "## Tool 1: Find me more like this one\n",
+    "\n",
+    "Cosine similarity on embeddings gives a ranked list of nearest neighbors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fadc0c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hit_idx = sequences.index(HIT_SEQUENCE)\n",
+    "hit_vec = mat[hit_idx]\n",
+    "hit_norm = hit_vec / np.linalg.norm(hit_vec)\n",
+    "\n",
+    "sims = []\n",
+    "for i, sid in enumerate(sequence_ids):\n",
+    "    if i == hit_idx:\n",
+    "        continue\n",
+    "    v = mat[i]\n",
+    "    sim = np.dot(hit_norm, v / np.linalg.norm(v))\n",
+    "    sims.append((sim, sequences[i]))\n",
+    "\n",
+    "sims.sort(reverse=True)\n",
+    "print(f\"Query: {HIT_SEQUENCE}\\n\")\n",
+    "print(\"Top 5 most similar sequences:\")\n",
+    "for sim, seq in sims[:5]:\n",
+    "    print(f\"  {sim:.3f}  {seq}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890c22d9",
+   "metadata": {},
+   "source": [
+    "## Tool 2: Is this sequence weird?\n",
+    "\n",
+    "Distance from the centroid flags outliers — contamination, misannotations, or genuinely novel variants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4bf611d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "centroid = mat.mean(axis=0)\n",
+    "distances = np.linalg.norm(mat - centroid, axis=1)\n",
+    "threshold = distances.mean() + 2 * distances.std()\n",
+    "\n",
+    "print(f\"Mean distance: {distances.mean():.3f}\")\n",
+    "print(f\"Outlier threshold (mean + 2σ): {threshold:.3f}\\n\")\n",
+    "\n",
+    "outliers = [(dist, seq) for dist, seq in zip(distances, sequences) if dist > threshold]\n",
+    "if outliers:\n",
+    "    print(\"Outlier sequences:\")\n",
+    "    for dist, seq in sorted(outliers, reverse=True):\n",
+    "        print(f\"  distance={dist:.3f}  {seq}\")\n",
+    "else:\n",
+    "    print(\"No outliers detected\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3847091e",
+   "metadata": {},
+   "source": [
+    "## Tool 3: Show me the landscape\n",
+    "\n",
+    "PCA gives a 2D map of the library. Color by any property to see functional structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c85a5552",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First get Tm predictions for coloring\n",
+    "pipeline2 = DataPipeline(sequences=LIBRARY, datastore=ds, verbose=True)\n",
+    "pipeline2.add_prediction(\"temperature-regression\", extractions=\"prediction\", columns=\"melting_temperature\")\n",
+    "pipeline2.run()\n",
+    "\n",
+    "tm_rows = ds.conn.execute(\"\"\"\n",
+    "    SELECT s.sequence_id, p.value AS tm\n",
+    "    FROM sequences s JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    WHERE p.prediction_type = 'melting_temperature'\n",
+    "    ORDER BY s.sequence_id\n",
+    "\"\"\").df()\n",
+    "tm_values = tm_rows[\"tm\"].values\n",
+    "\n",
+    "pca = PCA(n_components=2)\n",
+    "coords = pca.fit_transform(mat)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13, 5))\n",
+    "\n",
+    "# Left: colored by Tm\n",
+    "sc = axes[0].scatter(coords[:, 0], coords[:, 1], c=tm_values,\n",
+    "                     cmap=\"coolwarm\", edgecolors=\"black\", linewidth=0.3, alpha=0.85, s=60)\n",
+    "plt.colorbar(sc, ax=axes[0], label=\"Predicted Tm (°C)\")\n",
+    "axes[0].set_xlabel(f\"PC1 ({pca.explained_variance_ratio_[0]:.1%})\")\n",
+    "axes[0].set_ylabel(f\"PC2 ({pca.explained_variance_ratio_[1]:.1%})\")\n",
+    "axes[0].set_title(\"Library landscape — colored by predicted Tm\")\n",
+    "\n",
+    "# Right: highlight outliers\n",
+    "is_outlier = distances > threshold\n",
+    "axes[1].scatter(coords[~is_outlier, 0], coords[~is_outlier, 1],\n",
+    "                c=\"steelblue\", edgecolors=\"black\", linewidth=0.3, alpha=0.7, s=60, label=\"Normal\")\n",
+    "axes[1].scatter(coords[is_outlier, 0], coords[is_outlier, 1],\n",
+    "                c=\"crimson\", edgecolors=\"black\", linewidth=0.5, s=90, zorder=5, label=\"Outlier\")\n",
+    "axes[1].set_title(\"Outlier detection (>2σ from centroid)\")\n",
+    "axes[1].legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27de5acc",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "497f9bdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n",
+    "import os; os.remove(\"embedding_demo.duckdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.6_Fold_First.ipynb
+++ b/content/10.6_Fold_First.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2f321082",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Fold First\n\nUse Boltz-2 confidence scores as a coarse gate before downstream property predictions.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Using Boltz-2 in single-sequence (no-MSA) mode as a fast fold quality filter\n- Interpreting pLDDT, pTM, and interface PAE\n- Building a three-gate pipeline: fold → stability → solubility\n- When to use and when to skip the fold gate\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib\nexport BIOLMAI_TOKEN=your-token-here\n```\n\n> **Note:** This notebook requires Boltz-2 access via the BioLM API.\n> Confirm availability at [biolm.ai/models](https://biolm.ai/models)."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17e09786",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d117a737",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d4e9889",
+   "metadata": {},
+   "source": [
+    "## Designed library\n",
+    "\n",
+    "A mixed library of designed sequences — some will fold well, some won't."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ef17f41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DESIGNED_LIBRARY = [\n",
+    "    # Well-folded scaffolds (expected high pLDDT)\n",
+    "    \"MKTAYIAKQRQISFVKSHFSRQLEERVKILEQELEKAKEELKERLEELEKAKEEL\",\n",
+    "    \"GSHMDELYKAALEKAKQELKEAKQELKEAKQELKEAKQELKEAKQELKEAKQEL\",\n",
+    "    \"MHHHHHHSSGENLYFQGAEAAAKEAAAKEAAAKEAAAKEAAAKEAAAKEAAAK\",\n",
+    "    \"EVQLVESGGGLVQPGGSLRLSCAASGFNIKDTYIHWVRQAPGKGLEWVARI\",\n",
+    "    \"DIQMTQSPSSLSASVGDRVTITCRASQSISSYLNWYQQKPGKAPKLLIY\",\n",
+    "    # Likely disordered / low confidence\n",
+    "    \"GSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGSGS\",\n",
+    "    \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\n",
+    "    \"GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG\",\n",
+    "    \"KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK\",\n",
+    "    \"EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE\",\n",
+    "    # Mixed\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\",\n",
+    "    \"KWKLFKKIPKFLHLAKKF\",\n",
+    "    \"LLGDFFRKSKEKIGKEFKRIVQRIKDFLRNLVPRTES\",\n",
+    "]\n",
+    "print(f\"{len(DESIGNED_LIBRARY)} sequences in designed library\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4a6e594",
+   "metadata": {},
+   "source": [
+    "## The fold-first pipeline\n",
+    "\n",
+    "Three gates in sequence:\n",
+    "1. **Boltz-2 (no-MSA)** — fast coarse fold quality filter\n",
+    "2. **Melting temperature** — thermal stability (only runs on sequences that pass the fold gate)\n",
+    "3. **Solubility ranking** — final selection (only runs on sequences that pass both gates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35e96c89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = DataPipeline(sequences=DESIGNED_LIBRARY, verbose=True)\n",
+    "\n",
+    "# Gate 1: coarse fold quality (fast, no MSA)\n",
+    "pipeline.add_prediction(\n",
+    "    \"boltz2\", action=\"predict\",\n",
+    "    params={\"use_msa\": False},\n",
+    "    extractions=[\"mean_plddt\", \"ptm\"],\n",
+    "    columns=[\"plddt\", \"ptm\"],\n",
+    "    stage_name=\"fold_coarse\",\n",
+    ")\n",
+    "pipeline.add_filter(\n",
+    "    ThresholdFilter(\"plddt\", min_value=65.0),\n",
+    "    stage_name=\"fold_gate\",\n",
+    ")\n",
+    "\n",
+    "# Gate 2: stability (only for fold-passing sequences)\n",
+    "pipeline.add_prediction(\n",
+    "    \"temperature-regression\", extractions=\"prediction\",\n",
+    "    columns=\"melting_temperature\", stage_name=\"tm\",\n",
+    "    depends_on=[\"fold_gate\"],\n",
+    ")\n",
+    "pipeline.add_filter(\n",
+    "    ThresholdFilter(\"melting_temperature\", min_value=50.0),\n",
+    "    stage_name=\"tm_gate\",\n",
+    ")\n",
+    "\n",
+    "# Gate 3: solubility ranking\n",
+    "pipeline.add_prediction(\n",
+    "    \"biolmsol\", extractions=\"solubility_score\",\n",
+    "    columns=\"solubility\", stage_name=\"sol\",\n",
+    "    depends_on=[\"tm_gate\"],\n",
+    ")\n",
+    "pipeline.add_filter(\n",
+    "    RankingFilter(\"solubility\", n=5, ascending=False),\n",
+    "    stage_name=\"top_5\",\n",
+    ")\n",
+    "\n",
+    "pipeline.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b31e9a13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11a35373",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.plot(\"funnel\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "659e77e2",
+   "metadata": {},
+   "source": [
+    "## Inspect fold quality scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e97292",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fold_df = pipeline.query(\"\"\"\n",
+    "    SELECT s.sequence,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'plddt' THEN ROUND(p.value,1) END) AS plddt,\n",
+    "           MAX(CASE WHEN p.prediction_type = 'ptm'   THEN ROUND(p.value,3) END) AS ptm\n",
+    "    FROM sequences s\n",
+    "    JOIN predictions p ON s.sequence_id = p.sequence_id\n",
+    "    WHERE p.prediction_type IN ('plddt', 'ptm')\n",
+    "    GROUP BY s.sequence\n",
+    "    ORDER BY plddt DESC\n",
+    "\"\"\")\n",
+    "fold_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f9703e6",
+   "metadata": {},
+   "source": [
+    "## When to use (and skip) the fold gate\n",
+    "\n",
+    "**Always use it for:**\n",
+    "- Designed enzyme variants — if it doesn't fold, it doesn't catalyze\n",
+    "- Antibody and nanobody libraries — misfolded binders don't bind\n",
+    "- Scaffold-based design — low pLDDT means the design failed at the first hurdle\n",
+    "\n",
+    "**Skip it for:**\n",
+    "- Short peptides (<30 residues) — structure predictors aren't reliable here\n",
+    "- Intrinsically disordered proteins — low pLDDT is the correct prediction\n",
+    "- Peptide binders or disordered linkers — disorder may be the feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/10.6_Fold_First.ipynb
+++ b/content/10.6_Fold_First.ipynb
@@ -8,6 +8,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "learn-cell",
    "metadata": {},
    "source": "**What you'll learn:**\n- Using Boltz-2 in single-sequence (no-MSA) mode as a fast fold quality filter\n- Interpreting pLDDT, pTM, and interface PAE\n- Building a three-gate pipeline: fold → stability → solubility\n- When to use and when to skip the fold gate\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib\nexport BIOLMAI_TOKEN=your-token-here\n```\n\n> **Note:** This notebook requires Boltz-2 access via the BioLM API.\n> Confirm availability at [biolm.ai/models](https://biolm.ai/models)."

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ bqplot
 
 # Other
 biolmai
+biolmai[pipeline]
 biopython
 requests
 matplotlib


### PR DESCRIPTION
## Summary

Adds the 10.x pipeline tutorial series (PD-14) — 7 new Jupyter notebooks demonstrating the `biolmai.pipeline` DataPipeline / DuckDBDataStore SDK feature.

- `10.0` — Screen 1,000 Peptides Before Lunch (multi-stage pipeline, thermal stability + solubility filtering)
- `10.1` — Why DuckDB Inside the SDK
- `10.2` — Cluster By Embedding (ESM2 embeddings, k-means, PCA)
- `10.3` — Trickle Pattern (streaming/lazy evaluation)
- `10.4` — Mutation Scanning
- `10.5` — Protein Is A Point
- `10.6` — Fold First

## Preview banner

All 7 notebooks include a blockquote preview notice since `biolmai.pipeline` is not yet publicly released:

> **⚠️ Preview Feature** — The `biolmai.pipeline` module used in this guide is currently in preview and not yet publicly released. Access is available to early users on request. [Contact us](https://biolm.ai) to get access.

## Automation

Merging this PR will trigger the `notify-notebook-sync` workflow → dispatches to `biolm_web` → runs `convert_notebooks_to_html.py` (which now strips Pygments spans and fixes the Python logo) → opens a bot PR with regenerated HTML + migration.