### PR TITLE
feat: notify biolm-web on notebook changes

### DIFF
--- a/.github/workflows/notify-notebook-sync.yml
+++ b/.github/workflows/notify-notebook-sync.yml
@@ -7,6 +7,10 @@ on:
       - "content/*.ipynb"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -68,14 +72,14 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          repositories: biolm-web
+          repositories: biolm_web
 
-      - name: Dispatch to biolm-web
+      - name: Dispatch to biolm_web
         if: steps.detect.outputs.has_changes == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          repository: BioLM/biolm-web
+          repository: BioLM/biolm_web
           event-type: notebook-sync
           client-payload: |
             {

--- a/.github/workflows/notify-notebook-sync.yml
+++ b/.github/workflows/notify-notebook-sync.yml
@@ -1,0 +1,84 @@
+name: Notify biolm-web of Notebook Changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/*.ipynb"
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed notebooks
+        id: detect
+        run: |
+          python3 - <<'EOF'
+          import subprocess, json, os
+
+          # For workflow_dispatch, sync all notebooks
+          if os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch":
+              result = subprocess.run(
+                  ["find", "content", "-name", "*.ipynb"],
+                  capture_output=True, text=True,
+              )
+              notebooks = [
+                  {"filename": p.split("/")[-1], "change_type": "updated_notebook"}
+                  for p in result.stdout.strip().split("\n") if p
+              ]
+          else:
+              result = subprocess.run(
+                  ["git", "diff", "--name-status", "HEAD~1", "HEAD"],
+                  capture_output=True, text=True,
+              )
+              notebooks = {}
+              for line in result.stdout.strip().split("\n"):
+                  if not line:
+                      continue
+                  parts = line.split("\t")
+                  if len(parts) < 2:
+                      continue
+                  status, path = parts[0], parts[1]
+                  if not path.startswith("content/") or not path.endswith(".ipynb"):
+                      continue
+                  filename = path.split("/")[-1]
+                  if filename not in notebooks:
+                      notebooks[filename] = "new_notebook" if status == "A" else "updated_notebook"
+              notebooks = [{"filename": f, "change_type": ct} for f, ct in notebooks.items()]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              if notebooks:
+                  fh.write("has_changes=true\n")
+                  fh.write(f"notebooks={json.dumps(notebooks)}\n")
+                  print(f"Detected: {json.dumps(notebooks, indent=2)}")
+              else:
+                  fh.write("has_changes=false\n")
+                  print("No notebook changes detected")
+          EOF
+
+      - name: Generate GitHub App token
+        if: steps.detect.outputs.has_changes == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: biolm-web
+
+      - name: Dispatch to biolm-web
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: BioLM/biolm-web
+          event-type: notebook-sync
+          client-payload: |
+            {
+              "notebooks": ${{ steps.detect.outputs.notebooks }},
+              "source_sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## What this does

Adds `.github/workflows/notify-notebook-sync.yml` — the source-side trigger for the cross-repo notebook sync pipeline.

When `content/*.ipynb` files change on main, this workflow fires a `notebook-sync` `repository_dispatch` to `BioLM/biolm_web`. The handler there (`handle-notebook-sync.yml`) converts notebooks to self-contained HTML, generates a `JupyterPage` Django migration, and opens a bot PR. On next deploy, `manage.py migrate` loads the updated notebook pages into the DB.

`workflow_dispatch` is also supported for a full re-sync of all notebooks without needing a new commit (useful after merging the companion PR or recovering from a failed run).

---

## Flow

```
tutorials-and-guides: push to main (content/*.ipynb changed)
        ↓
notify-notebook-sync.yml (this file)
  - git diff HEAD~1 HEAD → detect changed .ipynb files
  - repository_dispatch → BioLM/biolm_web, event: notebook-sync
    payload: { notebooks: [{filename, change_type}], source_sha }
        ↓
biolm_web: handle-notebook-sync.yml
  - Checkout biolm_web + tutorials-and-guides
  - pip install nbconvert==7.16.4 nbformat==5.10.4 beautifulsoup4
  - python scripts/convert_notebooks_to_html.py  → jupyter_html/*.html
  - python scripts/generate_jupyter_migration.py → ui/migrations/XXXX_load_synced_jupyter_pages.py
  - peter-evans/create-pull-request → bot PR on biolm_web
```

---

## Auth

Uses the org-level `APP_ID` + `APP_PRIVATE_KEY` GitHub App secrets (same as protocol-sync and model-sync). No new secrets required.

---

## Companion PR

**BioLM/biolm_web #130** — adds `handle-notebook-sync.yml`, `scripts/generate_jupyter_migration.py`, and the `jupyter_html/` directory. Both PRs should be merged together (or biolm_web first).

---

## Fixes in latest commit (vs original PR)

- **Repo name bug**: `BioLM/biolm-web` (hyphen) → `BioLM/biolm_web` (underscore) in the dispatch target and app-token `repositories:` field. The hyphenated name would have silently failed — GitHub would return a 404 on dispatch.
- **Concurrency block**: added `cancel-in-progress: true` to match all other sync workflows in the pipeline.