### PR TITLE
test: trigger notebook sync pipeline with 10.2_Cluster_By_Embedding

### DIFF
--- a/content/10.2_Cluster_By_Embedding.ipynb
+++ b/content/10.2_Cluster_By_Embedding.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1b892f4b",
+   "metadata": {},
+   "source": "<div class=\"jupyter-biolm-header\">\n    <img style=\"float: left; padding-right: 10px; height: 60px\" src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/logo.png\">\n    <p>\n    <br>\n    <br>\n    <br>\n    </p>\n</div>\n\n# Cluster by Embedding\n\nESM2 embedding-based K-means clustering and PCA visualization of a peptide library.\n\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://www.svgrepo.com/show/354202/postman-icon.svg\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://api.biolm.ai/\">  <h5 style=\"margin: 0;\"><b>Postman API Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/1869px-Python-logo-notext.svg.png\" style=\"height: 15px; float: left; padding-right: 10px;\"><a href=\"https://docs.biolm.ai/en/latest/index.html\"><h5 style=\"margin: 0;\"><b>Python SDK Docs</b></h5></a>\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n        </td>\n    </tr>\n</table>\n\n<br>\n\n---"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "learn-cell",
+   "metadata": {},
+   "source": "**What you'll learn:**\n- Generating ESM2-8m embeddings via the pipeline SDK\n- K-means clustering with silhouette score selection\n- PCA visualization of sequence space\n- Diversity sampling across clusters\n\n**Requirements:**\n```\npip install biolmai[pipeline] matplotlib scikit-learn\nexport BIOLMAI_TOKEN=your-token-here\n```"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71bfc4f4",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e22429",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from biolmai.pipeline import (\n",
+    "    DataPipeline, DuckDBDataStore,\n",
+    "    ThresholdFilter, RankingFilter,\n",
+    "    ValidAminoAcidFilter, EmbeddingSpec,\n",
+    "    DiversitySamplingFilter,\n",
+    ")\n",
+    "\n",
+    "TOKEN = os.environ.get(\"BIOLMAI_TOKEN\", \"\")\n",
+    "if not TOKEN:\n",
+    "    raise EnvironmentError(\n",
+    "        \"Set BIOLMAI_TOKEN before running.\\n\"\n",
+    "        \"Get one at https://biolm.ai/ui/accounts/user-api-tokens/\"\n",
+    "    )\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.decomposition import PCA\n",
+    "from sklearn.metrics import silhouette_score\n",
+    "from sklearn.cluster import KMeans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db1bc4ec",
+   "metadata": {},
+   "source": [
+    "## Peptide library\n",
+    "\n",
+    "50 antimicrobial peptides from three families: magainins, defensins, and designed sequences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f54594c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MY_50_PEPTIDES = [\n",
+    "    \"GIGKFLHSAKKFGKAFVGEIMNS\", \"GIGKFLHSAGKFGKAFVGEIMKS\", \"GLFDIIKKIAESF\",\n",
+    "    \"GLFDIVKKVVGALGSL\", \"FLPLILRKIVTAL\", \"GIKKFLGSIWKFIKAFVKEIMN\",\n",
+    "    \"GLFDIIKKIAESFLPKV\", \"GIGKFLHSAKKFGKAFV\", \"GIGKFLHSAK\", \"GIGKFLHSAKKFGK\",\n",
+    "    \"LLGDFFRKSKEKIGKEFKRIVQRIKDFLRNLVPRTES\", \"RLFDKIRQVIRKF\",\n",
+    "    \"KWKLFKKIPKFLHLAKKF\", \"KWKLFKKIPKFLHLAK\", \"FKRIVQRIKDFL\",\n",
+    "    \"RWKIFKKIEKVGRNVRDGIIKAGPAVAVVGQATQIAK\",\n",
+    "    \"KWKLFKKIEKVGQNIRDGIIKAGPAVAVVGQATQIAK\",\n",
+    "    \"GIGAVLKVLTTGLPALISWIKRKRQQ\", \"VDKGSYLPRPTPPRPIYNRN\", \"GKPRPYSPRPTSHPRPIRV\",\n",
+    "    \"KLAKLAKKLAKLAK\", \"LKLLKKLLKLLKKL\", \"RRWWRRWWRR\", \"KWKWKWKWKW\",\n",
+    "    \"RRLCRIVVIRVCR\", \"RRWQWR\", \"RWRWRW\", \"KFLKKAKKFGK\",\n",
+    "    \"KWKLFKKI\", \"RLFDKIRQ\",\n",
+    "    \"ACYCRIPACIAGERRYGTCIYQGRLWAFCC\", \"GCSKNKGCSVDKECAAFGSR\",\n",
+    "    \"DCSCFGGKGETACNKCKTPEGKPCTEGKPCK\", \"GFCKLCCNPACGPNYKGICIDM\",\n",
+    "    \"AFGKQLAKLAKSKLAKLAKLAK\", \"KLALKLALKALKAALKLA\",\n",
+    "    \"WKWLKKWLKKLK\", \"RWKKWWRRKK\", \"KFKKLFKKLKK\",\n",
+    "    \"FLGALFKALSKLL\", \"ALLKFLLKFLLK\", \"GLLDFLK\",\n",
+    "    \"KKLFKKILKYL\", \"FFKDEL\", \"ILKKWPWWPWRR\",\n",
+    "    \"GLWSKIKEVGKEAAKAAAKAAGKAALNAVTGGGKPG\",\n",
+    "    \"KLKLLLLLKLK\", \"WKLFKKIKVWK\", \"KWKWFKKIKVWK\", \"KLFKKIKVWKK\",\n",
+    "]\n",
+    "print(f\"{len(MY_50_PEPTIDES)} peptides\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc67529a",
+   "metadata": {},
+   "source": [
+    "## Embed with ESM2-8m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85e36375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = DuckDBDataStore(\"cluster_demo.duckdb\")\n",
+    "\n",
+    "cp = DataPipeline(sequences=MY_50_PEPTIDES, datastore=ds, verbose=True)\n",
+    "cp.add_filter(ValidAminoAcidFilter(), stage_name=\"validate\")\n",
+    "cp.add_prediction(\n",
+    "    \"esm2-8m\", action=\"encode\",\n",
+    "    embedding_extractor=EmbeddingSpec(key=\"embeddings\", layer=6),\n",
+    "    stage_name=\"embed\", depends_on=[\"validate\"],\n",
+    ")\n",
+    "cp.add_clustering(\n",
+    "    method=\"kmeans\", n_clusters=3,\n",
+    "    similarity_metric=\"embedding\", embedding_model=\"esm2-8m\",\n",
+    "    stage_name=\"cluster_k3\", depends_on=[\"embed\"],\n",
+    ")\n",
+    "cp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca8de695",
+   "metadata": {},
+   "source": [
+    "## Choose k with silhouette scores\n",
+    "\n",
+    "Because embeddings are cached, re-clustering at different k values costs nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50f877e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sequence_ids = [r[0] for r in ds.conn.execute(\"SELECT sequence_id FROM sequences\").fetchall()]\n",
+    "emb_map = ds.get_embeddings_bulk(sequence_ids, model_name=\"esm2-8m\")\n",
+    "mat = np.stack([emb_map[sid] for sid in sequence_ids])\n",
+    "\n",
+    "scores = {}\n",
+    "for k in range(2, 9):\n",
+    "    labels = KMeans(n_clusters=k, random_state=42, n_init=10).fit_predict(mat)\n",
+    "    scores[k] = silhouette_score(mat, labels)\n",
+    "    print(f\"k={k}: silhouette={scores[k]:.3f}\")\n",
+    "\n",
+    "best_k = max(scores, key=scores.get)\n",
+    "print(f\"\\nBest k: {best_k}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31c7d18b",
+   "metadata": {},
+   "source": [
+    "## PCA visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e5a5723",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster_labels = [\n",
+    "    int(r[0]) for r in ds.conn.execute(\n",
+    "        \"SELECT CAST(value AS INTEGER) FROM predictions WHERE prediction_type='cluster_k3' ORDER BY sequence_id\"\n",
+    "    ).fetchall()\n",
+    "]\n",
+    "\n",
+    "pca = PCA(n_components=2)\n",
+    "coords = pca.fit_transform(mat)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "scatter = ax.scatter(coords[:, 0], coords[:, 1], c=cluster_labels,\n",
+    "                     cmap=\"Set1\", edgecolors=\"black\", linewidth=0.5, alpha=0.8, s=60)\n",
+    "plt.colorbar(scatter, ax=ax, label=\"Cluster\")\n",
+    "ax.set_xlabel(f\"PC1 ({pca.explained_variance_ratio_[0]:.1%} variance)\")\n",
+    "ax.set_ylabel(f\"PC2 ({pca.explained_variance_ratio_[1]:.1%} variance)\")\n",
+    "ax.set_title(\"ESM2-8m embedding space — K-means clusters (k=3)\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c8191c",
+   "metadata": {},
+   "source": [
+    "## Diversity sampling\n",
+    "\n",
+    "Select 20 maximally diverse representatives spanning all clusters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee2c646b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diverse_ds = DuckDBDataStore(\"diverse_demo.duckdb\")\n",
+    "\n",
+    "dp = DataPipeline(sequences=MY_50_PEPTIDES, datastore=diverse_ds, verbose=True)\n",
+    "dp.add_filter(ValidAminoAcidFilter(), stage_name=\"validate\")\n",
+    "dp.add_prediction(\n",
+    "    \"esm2-8m\", action=\"encode\",\n",
+    "    embedding_extractor=EmbeddingSpec(key=\"embeddings\", layer=6),\n",
+    "    stage_name=\"embed\", depends_on=[\"validate\"],\n",
+    ")\n",
+    "dp.add_clustering(\n",
+    "    method=\"kmeans\", n_clusters=3,\n",
+    "    similarity_metric=\"embedding\", embedding_model=\"esm2-8m\",\n",
+    "    stage_name=\"cluster\", depends_on=[\"embed\"],\n",
+    ")\n",
+    "dp.add_filter(DiversitySamplingFilter(n_samples=20, method=\"random\"), stage_name=\"diverse_20\")\n",
+    "dp.run()\n",
+    "dp.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6258bfbb",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7857400a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close(); diverse_ds.close()\n",
+    "import os\n",
+    "for f in [\"cluster_demo.duckdb\", \"diverse_demo.duckdb\"]:\n",
+    "    if os.path.exists(f): os.remove(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer-cell",
+   "metadata": {},
+   "source": "## Next Steps\n\nCheck out additional tutorials at [jupyter.biolm.ai](https://jupyter.biolm.ai),\nor head over to our [BioLM Documentation](https://docs.biolm.ai) to explore\nadditional models and functionality.\n\n#### See more use-cases and APIs on your [BioLM Console Catalog](https://biolm.ai/console/catalog/).\n<br>\n\n##### BioLM hosts deep learning models and runs inference at scale. You do the science.\n<br>\n\n<table class=\"jupyter-biolm-header-table\" style=\"width: 100%; border-collapse: collapse; background-color: white; float: left;\">\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/enzyme_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Enzyme Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/antibody_engineering_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Antibody Engineering\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/biosecurity_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Biosecurity\n        </td>\n    </tr>\n    <tr>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/single_cell_genomics_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Single-Cell Genomics\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/dna_seq_modeling_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> DNA Sequence Modelling\n        </td>\n        <td style=\"text-align: left; vertical-align: middle; background-color: white;\">\n            <img src=\"https://d31e6ufxekikrt.cloudfront.net/static/ui/images/console-overview/finetuning_icon.png\"  style=\"height: 40px; float: left; padding-right: 10px;\"> Finetuning\n        </td>\n    </tr>\n</table>\n\n#### [**Contact us**](https://biolm.ai/ui/contact-us/) to learn more."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Purpose

Smoke test for the new cross-repo notebook sync automation.

Merging this PR should:
1. Trigger `notify-notebook-sync.yml` (detects `content/10.2_Cluster_By_Embedding.ipynb` as added)
2. Fire `repository_dispatch` → `BioLM/biolm_web` with `event-type: notebook-sync`
3. `handle-notebook-sync.yml` runs in biolm_web:
   - Converts the notebook to self-contained HTML → `jupyter_html/`
   - Generates `ui/migrations/XXXX_load_synced_jupyter_pages.py`
   - Opens a bot PR on biolm_web

## What to verify after merge
- `notify-notebook-sync.yml` run appears in Actions tab — shows notebook detected, dispatch fired
- Bot PR appears on `BioLM/biolm_web` with branch `bot/notebook-sync-<sha>`
- Bot PR contains `jupyter_html/10.2_Cluster_By_Embedding.html` and a new `ui/migrations/` file

## Notebook
`10.2_Cluster_By_Embedding.ipynb` — ESM2 embedding-based K-means clustering and PCA visualization (from the `pd-14-pipeline-notebooks` series, tested locally end-to-end).